### PR TITLE
Improve the reliability of a successful compartment 2 run

### DIFF
--- a/tests/smokescreen/test_compartment_2.py
+++ b/tests/smokescreen/test_compartment_2.py
@@ -60,6 +60,7 @@ def test_compartment_2(page: Page, smokescreen_properties: dict) -> None:
         sample_date = datetime.now().strftime("%#d %b %Y")
         logging.info("Setting sample date to today's date")
         LogDevices(page).fill_sample_date_field(sample_date)
+        LogDevices(page).log_devices_title.get_by_text("Scan Device").wait_for()
         try:
             LogDevices(page).verify_successfully_logged_device_text()
             logging.info(f"{fit_device_id} Successfully logged")


### PR DESCRIPTION
…nd reduce the chance of fake negative test results

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->
This change is needed to increase the reliability of a successful run for compartment 2, and reduce the chances of getting false negative test results.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
The change is adding a wait_for() on the page title before checking that the device has been successfully logged. This is because sometimes playwright would expect the locator used to check the device has been successfully logged to be there before the page has loaded correctly.

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
