### PR TITLE
Making test_properties into its own util: BCSS-20024

### DIFF
--- a/tests/smokescreen/test_compartment_1.py
+++ b/tests/smokescreen/test_compartment_1.py
@@ -15,8 +15,7 @@ from utils.load_properties_file import PropertiesFile
 
 @pytest.fixture
 def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("compartment")
-    return properties
+    return PropertiesFile().get_smokescreen_properties()
 
 @pytest.mark.smoke
 @pytest.mark.compartment1

--- a/tests/smokescreen/test_compartment_1.py
+++ b/tests/smokescreen/test_compartment_1.py
@@ -1,7 +1,5 @@
-from sys import platform
 import pytest
 import logging
-from jproperties import Properties
 from pages.logout.log_out_page import Logout
 from utils.user_tools import UserTools
 from pages.base_page import BasePage
@@ -12,28 +10,13 @@ from pages.call_and_recall.create_a_plan_page import CreateAPlan
 from pages.call_and_recall.generate_invitations_page import GenerateInvitations
 from playwright.sync_api import Page
 from utils.batch_processing import batch_processing
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
 def smokescreen_properties() -> dict:
-    """
-    Reads the 'bcss_smokescreen_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_smokescreen_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open(
-            "tests/smokescreen/bcss_smokescreen_tests.properties", "rb"
-        ) as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_smokescreen_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
-
+    properties = PropertiesFile().smokescreen_properties("compartment")
+    return properties
 
 @pytest.mark.smoke
 @pytest.mark.compartment1

--- a/tests/smokescreen/test_compartment_2.py
+++ b/tests/smokescreen/test_compartment_2.py
@@ -15,8 +15,7 @@ from utils.load_properties_file import PropertiesFile
 
 @pytest.fixture
 def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("compartment")
-    return properties
+    return PropertiesFile().get_smokescreen_properties()
 
 
 @pytest.mark.smoke

--- a/tests/smokescreen/test_compartment_2.py
+++ b/tests/smokescreen/test_compartment_2.py
@@ -10,29 +10,13 @@ from utils.batch_processing import batch_processing
 from utils.fit_kit_generation import create_fit_id_df
 from utils.screening_subject_page_searcher import verify_subject_event_status_by_nhs_no
 from utils.user_tools import UserTools
-from jproperties import Properties
-from sys import platform
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
 def smokescreen_properties() -> dict:
-    """
-    Reads the 'bcss_smokescreen_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_smokescreen_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open(
-            "tests/smokescreen/bcss_smokescreen_tests.properties", "rb"
-        ) as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_smokescreen_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
+    properties = PropertiesFile().smokescreen_properties("compartment")
+    return properties
 
 
 @pytest.mark.smoke

--- a/tests/smokescreen/test_compartment_3.py
+++ b/tests/smokescreen/test_compartment_3.py
@@ -10,29 +10,13 @@ from utils.oracle.oracle_specific_functions import (
     execute_fit_kit_stored_procedures,
 )
 from utils.user_tools import UserTools
-from jproperties import Properties
-from sys import platform
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
 def smokescreen_properties() -> dict:
-    """
-    Reads the 'bcss_smokescreen_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_smokescreen_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open(
-            "tests/smokescreen/bcss_smokescreen_tests.properties", "rb"
-        ) as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_smokescreen_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
+    properties = PropertiesFile().smokescreen_properties("compartment")
+    return properties
 
 
 @pytest.mark.smokescreen

--- a/tests/smokescreen/test_compartment_3.py
+++ b/tests/smokescreen/test_compartment_3.py
@@ -15,8 +15,7 @@ from utils.load_properties_file import PropertiesFile
 
 @pytest.fixture
 def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("compartment")
-    return properties
+    return PropertiesFile().get_smokescreen_properties()
 
 
 @pytest.mark.smokescreen

--- a/tests/test_call_and_recall_page.py
+++ b/tests/test_call_and_recall_page.py
@@ -13,9 +13,8 @@ from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("smoke")
-    return properties
+def general_properties() -> dict:
+    return PropertiesFile().get_general_properties()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -65,7 +64,7 @@ def test_call_and_recall_page_navigation(page: Page) -> None:
     BasePage(page).main_menu_header_is_displayed()
 
 
-def test_view_an_invitation_plan(page: Page, smokescreen_properties: dict) -> None:
+def test_view_an_invitation_plan(page: Page, general_properties: dict) -> None:
     """
     Confirms that an invitation plan can be viewed via a screening centre from the planning ad monitoring page
     """
@@ -74,7 +73,7 @@ def test_view_an_invitation_plan(page: Page, smokescreen_properties: dict) -> No
 
     # Select a screening centre
     InvitationsMonitoring(page).go_to_invitation_plan_page(
-        smokescreen_properties["screening_centre_code"]
+        general_properties["screening_centre_code"]
     )
 
     # Select an invitation plan

--- a/tests/test_call_and_recall_page.py
+++ b/tests/test_call_and_recall_page.py
@@ -1,5 +1,4 @@
 import pytest
-from sys import platform
 from playwright.sync_api import Page
 from pages.base_page import BasePage
 from pages.call_and_recall.call_and_recall_page import CallAndRecall
@@ -10,26 +9,13 @@ from pages.call_and_recall.age_extension_rollout_plans_page import AgeExtensionR
 from pages.call_and_recall.invitations_plans_page import InvitationsPlans
 from pages.call_and_recall.create_a_plan_page import CreateAPlan
 from utils.user_tools import UserTools
-from jproperties import Properties
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def tests_properties() -> dict:
-    """
-    Reads the 'bcss_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open("tests/bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
+def smokescreen_properties() -> dict:
+    properties = PropertiesFile().smokescreen_properties("smoke")
+    return properties
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -79,7 +65,7 @@ def test_call_and_recall_page_navigation(page: Page) -> None:
     BasePage(page).main_menu_header_is_displayed()
 
 
-def test_view_an_invitation_plan(page: Page, tests_properties: dict) -> None:
+def test_view_an_invitation_plan(page: Page, smokescreen_properties: dict) -> None:
     """
     Confirms that an invitation plan can be viewed via a screening centre from the planning ad monitoring page
     """
@@ -88,7 +74,7 @@ def test_view_an_invitation_plan(page: Page, tests_properties: dict) -> None:
 
     # Select a screening centre
     InvitationsMonitoring(page).go_to_invitation_plan_page(
-        tests_properties["screening_centre_code"]
+        smokescreen_properties["screening_centre_code"]
     )
 
     # Select an invitation plan

--- a/tests/test_organisations_page.py
+++ b/tests/test_organisations_page.py
@@ -1,29 +1,15 @@
-from sys import platform
 import pytest
-from jproperties import Properties
 from playwright.sync_api import Page, expect
 from pages.base_page import BasePage
 from pages.organisations.organisations_page import OrganisationsPage
 from utils.user_tools import UserTools
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def tests_properties() -> dict:
-    """
-    Reads the 'bcss_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open("tests/bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
+def smokescreen_properties() -> dict:
+    properties = PropertiesFile().smokescreen_properties("smoke")
+    return properties
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -86,7 +72,7 @@ def test_organisations_page_navigation(page: Page) -> None:
 
 
 def test_view_an_organisations_system_parameters(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms that an organisation's system parameters can be accessed and viewed
@@ -95,7 +81,7 @@ def test_view_an_organisations_system_parameters(
     OrganisationsPage(page).go_to_screening_centre_parameters_page()
 
     # View an Organisation
-    page.get_by_role("link", name=tests_properties["screening_centre_code"]).click()
+    page.get_by_role("link", name=smokescreen_properties["screening_centre_code"]).click()
     BasePage(page).bowel_cancer_screening_ntsh_page_title_contains_text(
         "System Parameters"
     )

--- a/tests/test_organisations_page.py
+++ b/tests/test_organisations_page.py
@@ -7,9 +7,8 @@ from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("smoke")
-    return properties
+def general_properties() -> dict:
+    return PropertiesFile().get_general_properties()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -72,7 +71,7 @@ def test_organisations_page_navigation(page: Page) -> None:
 
 
 def test_view_an_organisations_system_parameters(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms that an organisation's system parameters can be accessed and viewed
@@ -81,7 +80,7 @@ def test_view_an_organisations_system_parameters(
     OrganisationsPage(page).go_to_screening_centre_parameters_page()
 
     # View an Organisation
-    page.get_by_role("link", name=smokescreen_properties["screening_centre_code"]).click()
+    page.get_by_role("link", name=general_properties["screening_centre_code"]).click()
     BasePage(page).bowel_cancer_screening_ntsh_page_title_contains_text(
         "System Parameters"
     )

--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -1,30 +1,16 @@
 import pytest
 from playwright.sync_api import Page, expect
-from sys import platform
 from pages.base_page import BasePage
 from pages.reports.reports_page import ReportsPage
 from utils.date_time_utils import DateTimeUtils
 from utils.user_tools import UserTools
-from jproperties import Properties
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def tests_properties() -> dict:
-    """
-    Reads the 'bcss_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open("tests/bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
+def smokescreen_properties() -> dict:
+    properties = PropertiesFile().smokescreen_properties("smoke")
+    return properties
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -204,7 +190,7 @@ def test_failsafe_reports_subjects_ceased_due_to_date_of_birth_changes(
 
 
 def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundaries(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms 'allocate_sc_for_patient_movements_within_hub_boundaries' page loads,
@@ -247,7 +233,7 @@ def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundarie
 
     # Select another screening centre
     set_patients_screening_centre_dropdown.select_option(
-        tests_properties["coventry_and_warwickshire_bcs_centre"]
+        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Click update
@@ -255,7 +241,7 @@ def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundarie
 
     # Verify new screening centre has saved
     expect(ReportsPage(page).set_patients_screening_centre_dropdown).to_have_value(
-        tests_properties["coventry_and_warwickshire_bcs_centre"]
+        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
 
@@ -346,7 +332,7 @@ def test_failsafe_reports_identify_and_link_new_gp(page: Page) -> None:
 
 # Operational Reports
 def test_operational_reports_appointment_attendance_not_updated(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms 'appointment_attendance_not_updated' page loads,
@@ -375,7 +361,7 @@ def test_operational_reports_appointment_attendance_not_updated(
 
     # Select a screening centre from the drop-down options
     set_patients_screening_centre_dropdown.select_option(
-        tests_properties["coventry_and_warwickshire_bcs_centre"]
+        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Click "Generate Report" button
@@ -447,7 +433,7 @@ def test_operational_reports_demographic_update_inconsistent_with_manual_update(
 
 
 def test_operational_reports_screening_practitioner_6_weeks_availability_not_set_up(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms 'screening_practitioner_6_weeks_availability_not_set_up_report' page loads,
@@ -474,7 +460,7 @@ def test_operational_reports_screening_practitioner_6_weeks_availability_not_set
 
     # Select a screening centre
     set_patients_screening_centre_dropdown.select_option(
-        tests_properties["coventry_and_warwickshire_bcs_centre"]
+        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Click "Generate Report"
@@ -494,7 +480,7 @@ def test_operational_reports_screening_practitioner_6_weeks_availability_not_set
 
 @pytest.mark.only
 def test_operational_reports_screening_practitioner_appointments(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms 'screening_practitioner_appointments' page loads,
@@ -523,12 +509,12 @@ def test_operational_reports_screening_practitioner_appointments(
 
     # Select a screening centre
     set_patients_screening_centre_dropdown.select_option(
-        tests_properties["coventry_and_warwickshire_bcs_centre"]
+        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Select a screening practitioner
     screening_practitioner_dropdown.select_option(
-        tests_properties["screening_practitioner_named_another_stubble"]
+        smokescreen_properties["screening_practitioner_named_another_stubble"]
     )
 
     # Click "Generate Report"

--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -8,9 +8,8 @@ from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("smoke")
-    return properties
+def general_properties() -> dict:
+    return PropertiesFile().get_general_properties()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -190,7 +189,7 @@ def test_failsafe_reports_subjects_ceased_due_to_date_of_birth_changes(
 
 
 def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundaries(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms 'allocate_sc_for_patient_movements_within_hub_boundaries' page loads,
@@ -233,7 +232,7 @@ def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundarie
 
     # Select another screening centre
     set_patients_screening_centre_dropdown.select_option(
-        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
+        general_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Click update
@@ -241,7 +240,7 @@ def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundarie
 
     # Verify new screening centre has saved
     expect(ReportsPage(page).set_patients_screening_centre_dropdown).to_have_value(
-        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
+        general_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
 
@@ -332,7 +331,7 @@ def test_failsafe_reports_identify_and_link_new_gp(page: Page) -> None:
 
 # Operational Reports
 def test_operational_reports_appointment_attendance_not_updated(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms 'appointment_attendance_not_updated' page loads,
@@ -361,7 +360,7 @@ def test_operational_reports_appointment_attendance_not_updated(
 
     # Select a screening centre from the drop-down options
     set_patients_screening_centre_dropdown.select_option(
-        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
+        general_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Click "Generate Report" button
@@ -433,7 +432,7 @@ def test_operational_reports_demographic_update_inconsistent_with_manual_update(
 
 
 def test_operational_reports_screening_practitioner_6_weeks_availability_not_set_up(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms 'screening_practitioner_6_weeks_availability_not_set_up_report' page loads,
@@ -460,7 +459,7 @@ def test_operational_reports_screening_practitioner_6_weeks_availability_not_set
 
     # Select a screening centre
     set_patients_screening_centre_dropdown.select_option(
-        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
+        general_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Click "Generate Report"
@@ -480,7 +479,7 @@ def test_operational_reports_screening_practitioner_6_weeks_availability_not_set
 
 @pytest.mark.only
 def test_operational_reports_screening_practitioner_appointments(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms 'screening_practitioner_appointments' page loads,
@@ -509,12 +508,12 @@ def test_operational_reports_screening_practitioner_appointments(
 
     # Select a screening centre
     set_patients_screening_centre_dropdown.select_option(
-        smokescreen_properties["coventry_and_warwickshire_bcs_centre"]
+        general_properties["coventry_and_warwickshire_bcs_centre"]
     )
 
     # Select a screening practitioner
     screening_practitioner_dropdown.select_option(
-        smokescreen_properties["screening_practitioner_named_another_stubble"]
+        general_properties["screening_practitioner_named_another_stubble"]
     )
 
     # Click "Generate Report"

--- a/tests/test_screening_subject_search_page.py
+++ b/tests/test_screening_subject_search_page.py
@@ -24,9 +24,8 @@ from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def smokescreen_properties() -> dict:
-    properties = PropertiesFile().smokescreen_properties("smoke")
-    return properties
+def general_properties() -> dict:
+    return PropertiesFile().get_general_properties()
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -44,7 +43,7 @@ def before_each(page: Page):
 
 @pytest.mark.smoke
 def test_search_screening_subject_by_nhs_number(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their nhs number by doing the following:
@@ -54,11 +53,11 @@ def test_search_screening_subject_by_nhs_number(
     - Click search button
     - Verify the Subject Screening Summary page is displayed
     """
-    search_subject_by_nhs_number(page, smokescreen_properties["nhs_number"])
+    search_subject_by_nhs_number(page, general_properties["nhs_number"])
 
 
 def test_search_screening_subject_by_surname(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their surname by doing the following:
@@ -68,11 +67,11 @@ def test_search_screening_subject_by_surname(
     - Click search button
     - Verify the subject summary page is displayed
     """
-    search_subject_by_surname(page, smokescreen_properties["surname"])
+    search_subject_by_surname(page, general_properties["surname"])
 
 
 def test_search_screening_subject_by_forename(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their forename by doing the following:
@@ -82,10 +81,10 @@ def test_search_screening_subject_by_forename(
     - Click search button
     - Verify the subject summary page is displayed
     """
-    search_subject_by_forename(page, smokescreen_properties["forename"])
+    search_subject_by_forename(page, general_properties["forename"])
 
 
-def test_search_screening_subject_by_dob(page: Page, smokescreen_properties: dict) -> None:
+def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -> None:
     """
     Confirms a screening subject can be searched for, using their date of birth by doing the following:
     - Clear filters
@@ -94,7 +93,7 @@ def test_search_screening_subject_by_dob(page: Page, smokescreen_properties: dic
     - Click search button
     - Verify the subject search results page is displayed
     """
-    search_subject_by_dob(page, smokescreen_properties["subject_dob"])
+    search_subject_by_dob(page, general_properties["subject_dob"])
 
 
 def test_search_screening_subject_by_postcode(page: Page) -> None:
@@ -110,7 +109,7 @@ def test_search_screening_subject_by_postcode(page: Page) -> None:
 
 
 def test_search_screening_subject_by_episode_closed_date(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their episode closed date by doing the following:
@@ -121,18 +120,18 @@ def test_search_screening_subject_by_episode_closed_date(
     - Verify the subject search results page is displayed
     - Verify the results contain the date that was searched for
     """
-    search_subject_by_episode_closed_date(page, smokescreen_properties["episode_closed_date"])
+    search_subject_by_episode_closed_date(page, general_properties["episode_closed_date"])
 
 
 def test_search_criteria_clear_filters_button(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms the 'clear filters' button on the search page works as expected by doing the following:
     - Enter number in NHS field and verify value
     - Click clear filters button and verify field is empty
     """
-    check_clear_filters_button_works(page, smokescreen_properties["nhs_number"])
+    check_clear_filters_button_works(page, general_properties["nhs_number"])
 
 
 # Tests searching via the "Screening Status" drop down list
@@ -345,7 +344,7 @@ def test_search_screening_subject_by_home_hub(page: Page) -> None:
 
 
 def test_search_screening_subject_by_gp_practice(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (home hub) by doing the following:
@@ -361,12 +360,12 @@ def test_search_screening_subject_by_gp_practice(
         page,
         ScreeningStatusSearchOptions.CALL_STATUS.value,
         SearchAreaSearchOptions.SEARCH_AREA_GP_PRACTICE.value,
-        smokescreen_properties["gp_practice_code"],
+        general_properties["gp_practice_code"],
     )
     SubjectScreeningSummary(page).verify_result_contains_text("SPRINGS HEALTH CENTRE")
 
 
-def test_search_screening_subject_by_ccg(page: Page, smokescreen_properties: dict) -> None:
+def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (ccg) by doing the following:
     - Clear filters
@@ -381,13 +380,13 @@ def test_search_screening_subject_by_ccg(page: Page, smokescreen_properties: dic
         page,
         ScreeningStatusSearchOptions.CALL_STATUS.value,
         SearchAreaSearchOptions.SEARCH_AREA_CCG.value,
-        smokescreen_properties["ccg_code"],
-        smokescreen_properties["gp_practice_code"],
+        general_properties["ccg_code"],
+        general_properties["gp_practice_code"],
     )
 
 
 def test_search_screening_subject_by_screening_centre(
-    page: Page, smokescreen_properties: dict
+    page: Page, general_properties: dict
 ) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (screening centre) by doing the following:
@@ -402,7 +401,7 @@ def test_search_screening_subject_by_screening_centre(
         page,
         ScreeningStatusSearchOptions.CALL_STATUS.value,
         SearchAreaSearchOptions.SEARCH_AREA_CCG.value,
-        smokescreen_properties["screening_centre_code"],
+        general_properties["screening_centre_code"],
     )
 
 

--- a/tests/test_screening_subject_search_page.py
+++ b/tests/test_screening_subject_search_page.py
@@ -1,6 +1,5 @@
 import pytest
-from sys import platform
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page
 from pages.base_page import BasePage
 from pages.screening_subject_search.subject_screening_search_page import (
     ScreeningStatusSearchOptions,
@@ -21,26 +20,13 @@ from utils.screening_subject_page_searcher import (
     search_subject_by_search_area,
 )
 from utils.user_tools import UserTools
-from jproperties import Properties
+from utils.load_properties_file import PropertiesFile
 
 
 @pytest.fixture
-def tests_properties() -> dict:
-    """
-    Reads the 'bcss_tests.properties' file and populates a 'Properties' object.
-    Returns a dictionary of properties for use in tests.
-
-    Returns:
-        dict: A dictionary containing the values loaded from the 'bcss_tests.properties' file.
-    """
-    configs = Properties()
-    if platform == "win32":  # File path from content root is required on Windows OS
-        with open("tests/bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    elif platform == "darwin":  # Only the filename is required on macOS
-        with open("bcss_tests.properties", "rb") as read_prop:
-            configs.load(read_prop)
-    return configs.properties
+def smokescreen_properties() -> dict:
+    properties = PropertiesFile().smokescreen_properties("smoke")
+    return properties
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -58,7 +44,7 @@ def before_each(page: Page):
 
 @pytest.mark.smoke
 def test_search_screening_subject_by_nhs_number(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their nhs number by doing the following:
@@ -68,11 +54,11 @@ def test_search_screening_subject_by_nhs_number(
     - Click search button
     - Verify the Subject Screening Summary page is displayed
     """
-    search_subject_by_nhs_number(page, tests_properties["nhs_number"])
+    search_subject_by_nhs_number(page, smokescreen_properties["nhs_number"])
 
 
 def test_search_screening_subject_by_surname(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their surname by doing the following:
@@ -82,11 +68,11 @@ def test_search_screening_subject_by_surname(
     - Click search button
     - Verify the subject summary page is displayed
     """
-    search_subject_by_surname(page, tests_properties["surname"])
+    search_subject_by_surname(page, smokescreen_properties["surname"])
 
 
 def test_search_screening_subject_by_forename(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their forename by doing the following:
@@ -96,10 +82,10 @@ def test_search_screening_subject_by_forename(
     - Click search button
     - Verify the subject summary page is displayed
     """
-    search_subject_by_forename(page, tests_properties["forename"])
+    search_subject_by_forename(page, smokescreen_properties["forename"])
 
 
-def test_search_screening_subject_by_dob(page: Page, tests_properties: dict) -> None:
+def test_search_screening_subject_by_dob(page: Page, smokescreen_properties: dict) -> None:
     """
     Confirms a screening subject can be searched for, using their date of birth by doing the following:
     - Clear filters
@@ -108,7 +94,7 @@ def test_search_screening_subject_by_dob(page: Page, tests_properties: dict) -> 
     - Click search button
     - Verify the subject search results page is displayed
     """
-    search_subject_by_dob(page, tests_properties["subject_dob"])
+    search_subject_by_dob(page, smokescreen_properties["subject_dob"])
 
 
 def test_search_screening_subject_by_postcode(page: Page) -> None:
@@ -124,7 +110,7 @@ def test_search_screening_subject_by_postcode(page: Page) -> None:
 
 
 def test_search_screening_subject_by_episode_closed_date(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms a screening subject can be searched for, using their episode closed date by doing the following:
@@ -135,18 +121,18 @@ def test_search_screening_subject_by_episode_closed_date(
     - Verify the subject search results page is displayed
     - Verify the results contain the date that was searched for
     """
-    search_subject_by_episode_closed_date(page, tests_properties["episode_closed_date"])
+    search_subject_by_episode_closed_date(page, smokescreen_properties["episode_closed_date"])
 
 
 def test_search_criteria_clear_filters_button(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms the 'clear filters' button on the search page works as expected by doing the following:
     - Enter number in NHS field and verify value
     - Click clear filters button and verify field is empty
     """
-    check_clear_filters_button_works(page, tests_properties["nhs_number"])
+    check_clear_filters_button_works(page, smokescreen_properties["nhs_number"])
 
 
 # Tests searching via the "Screening Status" drop down list
@@ -359,7 +345,7 @@ def test_search_screening_subject_by_home_hub(page: Page) -> None:
 
 
 def test_search_screening_subject_by_gp_practice(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (home hub) by doing the following:
@@ -375,12 +361,12 @@ def test_search_screening_subject_by_gp_practice(
         page,
         ScreeningStatusSearchOptions.CALL_STATUS.value,
         SearchAreaSearchOptions.SEARCH_AREA_GP_PRACTICE.value,
-        tests_properties["gp_practice_code"],
+        smokescreen_properties["gp_practice_code"],
     )
     SubjectScreeningSummary(page).verify_result_contains_text("SPRINGS HEALTH CENTRE")
 
 
-def test_search_screening_subject_by_ccg(page: Page, tests_properties: dict) -> None:
+def test_search_screening_subject_by_ccg(page: Page, smokescreen_properties: dict) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (ccg) by doing the following:
     - Clear filters
@@ -395,13 +381,13 @@ def test_search_screening_subject_by_ccg(page: Page, tests_properties: dict) -> 
         page,
         ScreeningStatusSearchOptions.CALL_STATUS.value,
         SearchAreaSearchOptions.SEARCH_AREA_CCG.value,
-        tests_properties["ccg_code"],
-        tests_properties["gp_practice_code"],
+        smokescreen_properties["ccg_code"],
+        smokescreen_properties["gp_practice_code"],
     )
 
 
 def test_search_screening_subject_by_screening_centre(
-    page: Page, tests_properties: dict
+    page: Page, smokescreen_properties: dict
 ) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (screening centre) by doing the following:
@@ -416,7 +402,7 @@ def test_search_screening_subject_by_screening_centre(
         page,
         ScreeningStatusSearchOptions.CALL_STATUS.value,
         SearchAreaSearchOptions.SEARCH_AREA_CCG.value,
-        tests_properties["screening_centre_code"],
+        smokescreen_properties["screening_centre_code"],
     )
 
 

--- a/utils/load_properties_file.py
+++ b/utils/load_properties_file.py
@@ -28,7 +28,7 @@ class PropertiesFile():
     def get_smokescreen_properties(self) -> dict:
         "This is used to get the `tests/smokescreen/bcss_smokescreen_tests.properties` file"
         return self.get_properties("smokescreen")
-    
+
 
     def get_general_properties(self) -> dict:
         "This is used to get the `tests/bcss_tests.properties` file"

--- a/utils/load_properties_file.py
+++ b/utils/load_properties_file.py
@@ -4,22 +4,33 @@ import os
 
 class PropertiesFile():
     def __init__(self):
-        self.compartment_properties_file = "tests/smokescreen/bcss_smokescreen_tests.properties"
-        self.smokescreen_properties_file = "tests/bcss_tests.properties"
+        self.smokescreen_properties_file = "tests/smokescreen/bcss_smokescreen_tests.properties"
+        self.general_properties_file = "tests/bcss_tests.properties"
 
 
-    def smokescreen_properties(self, type_of_properties_file: str) -> dict:
+    def get_properties(self, type_of_properties_file: str | None = None) -> dict:
         """
-        Reads the 'bcss_smokescreen_tests.properties' file or 'bcss_tests.properties' and populates a 'Properties' object depending on whether "compartment" is given
+        Reads the 'bcss_smokescreen_tests.properties' file or 'bcss_tests.properties' and populates a 'Properties' object depending on whether "smokescreen" is given
         Returns a dictionary of properties for use in tests.
 
         Returns:
             dict: A dictionary containing the values loaded from the 'bcss_smokescreen_tests.properties' file.
         """
         configs = Properties()
-        path =  f"{os.getcwd()}/{self.compartment_properties_file if type_of_properties_file == "compartment" else self.smokescreen_properties_file}"
+        path =  f"{os.getcwd()}/{self.smokescreen_properties_file if type_of_properties_file == "smokescreen" else self.general_properties_file}"
         with open(
             path, "rb"
             ) as read_prop:
             configs.load(read_prop)
         return configs.properties
+
+
+    def get_smokescreen_properties(self) -> dict:
+        "This is used to get the `tests/smokescreen/bcss_smokescreen_tests.properties` file"
+        return self.get_properties("smokescreen")
+    
+
+    def get_general_properties(self) -> dict:
+        "This is used to get the `tests/bcss_tests.properties` file"
+        return self.get_properties()
+

--- a/utils/load_properties_file.py
+++ b/utils/load_properties_file.py
@@ -1,0 +1,25 @@
+from jproperties import Properties
+import os
+
+
+class PropertiesFile():
+    def __init__(self):
+        self.compartment_properties_file = "tests/smokescreen/bcss_smokescreen_tests.properties"
+        self.smokescreen_properties_file = "tests/bcss_tests.properties"
+
+
+    def smokescreen_properties(self, type_of_properties_file: str) -> dict:
+        """
+        Reads the 'bcss_smokescreen_tests.properties' file or 'bcss_tests.properties' and populates a 'Properties' object depending on whether "compartment" is given
+        Returns a dictionary of properties for use in tests.
+
+        Returns:
+            dict: A dictionary containing the values loaded from the 'bcss_smokescreen_tests.properties' file.
+        """
+        configs = Properties()
+        path =  f"{os.getcwd()}/{self.compartment_properties_file if type_of_properties_file == "compartment" else self.smokescreen_properties_file}"
+        with open(
+            path, "rb"
+            ) as read_prop:
+            configs.load(read_prop)
+        return configs.properties


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
This is moving all of the smokescreen_properties/test_properties methods into a util to be used by all tests.
As there are two different property files, one for the compartments and one for the rest I added an if statement to select between them depending on the input provided

This change is tracked by the Jira ticket: [BCSS-20024](https://nhsd-jira.digital.nhs.uk/browse/BCSS-20024)

## Context

<!-- Why is this change required? What problem does it solve? -->
This helps to reduce the number of duplicate code and we can easier load the properties file across all of our tests with the same method, instead of repeating it again for each test.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
