### PR TITLE
Updated DateTimeUtils to allow for bcss displaying timestamps in UTC

### DIFF
--- a/utils/date_time_utils.py
+++ b/utils/date_time_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import pytz
 
 
 class DateTimeUtils:
@@ -71,14 +72,26 @@ class DateTimeUtils:
     @staticmethod
     def report_timestamp_date_format() -> str:
         """Gets the current datetime in the timestamp format used on the report pages."""
-        return DateTimeUtils.format_date(datetime.now(), "%d/%m/%Y at %H:%M:%S")
+        # Use this option if bcss is displaying correct DST times
+        # return DateTimeUtils.format_date(datetime.now(), "%d/%m/%Y at %H:%M:%S")
+
+        # Use this option if bcss is displaying UTC times
+        return DateTimeUtils.format_date(datetime.now(pytz.utc), "%d/%m/%Y at %H:%M:%S")
 
     @staticmethod
     def fobt_kits_logged_but_not_read_report_timestamp_date_format() -> str:
         """Gets the current datetime in the format used for FOBT Kits Logged but Not Read report."""
+        # Use this option if bcss is displaying correct DST times
         return DateTimeUtils.format_date(datetime.now(), "%d %b %Y %H:%M:%S")
+
+        # Use this option if bcss is displaying UTC times
+        # return DateTimeUtils.format_date(datetime.now(pytz.utc), "%d %b %Y %H:%M:%S")
 
     @staticmethod
     def screening_practitioner_appointments_report_timestamp_date_format() -> str:
         """Gets the current datetime in the format used for Screening Practitioner Appointments report."""
-        return DateTimeUtils.format_date(datetime.now(), "%d.%m.%Y at %H:%M:%S")
+        # Use this option if bcss is displaying correct DST times
+        # return DateTimeUtils.format_date(datetime.now(), "%d.%m.%Y at %H:%M:%S")
+
+        # Use this option if bcss is displaying UTC times
+        return DateTimeUtils.format_date(datetime.now(pytz.utc), "%d.%m.%Y at %H:%M:%S")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Our reports tests verify timestamps and not all of the timestamps in bcss display the timestamp in DST so several tests are failing. I've made some changes to the DateTimeUtil to allow us to assert timestamps in either DST or UTC, depending on the current bcss app settings.

## Context

<!-- Why is this change required? What problem does it solve? -->
This allows the timestamp verification steps to pass, until the issue has been resolved in the app.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes (where appropriate)
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
