### PR TITLE
Fixed failing test

### DIFF
--- a/tests/smokescreen/test_compartment_5.py
+++ b/tests/smokescreen/test_compartment_5.py
@@ -162,7 +162,7 @@ def test_compartment_5(page: Page, smokescreen_properties: dict) -> None:
 
         logging.info(f"Inviting {name_from_util} to diagnostic test")
         AdvanceFOBTScreeningEpisodePage(page).click_invite_for_diagnostic_test_button()
-        SubjectScreeningSummaryPage(page).verify_latest_event_status_value(
+        AdvanceFOBTScreeningEpisodePage(page).verify_latest_event_status_value(
             "A59 - Invited for Diagnostic Test"
         )
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Fixed an issue where the compartment 5 test would fail.
This was due to referencing the incorrect POM

## Context

<!-- Why is this change required? What problem does it solve? -->
Fixed the false negative test to now work.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
