### PR TITLE
Feature/bcss 20540 refactor main menu click

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -7,6 +7,8 @@ class BasePage:
 
     def __init__(self, page: Page):
         self.page = page
+        # Homepage - vars
+        self.main_menu_string = "Main Menu"
         # Homepage/Navigation Bar links
         self.sub_menu_link = self.page.get_by_role("link", name="Show Sub-menu")
         self.hide_sub_menu_link = self.page.get_by_role("link", name="Hide Sub-menu")
@@ -16,7 +18,7 @@ class BasePage:
         self.refresh_alerts_link = self.page.get_by_role("link", name="Refresh alerts")
         self.user_guide_link = self.page.get_by_role("link", name="User guide")
         self.help_link = self.page.get_by_role("link", name="Help")
-        self.main_menu_link = self.page.get_by_role("link", name="Main Menu")
+        self.main_menu_link = self.page.get_by_role("link", name=self.main_menu_string)
         self.log_out_link = self.page.get_by_role("link", name="Log-out")
         # Main menu - page links
         self.contacts_list_page = self.page.get_by_role("link", name="Contacts List")
@@ -54,8 +56,27 @@ class BasePage:
 
     def click_main_menu_link(self) -> None:
         """Click the Base Page 'Main Menu' link if it is visible."""
-        if self.main_menu_link.is_visible():
-            self.click(self.main_menu_link)
+        loops = 0
+        while loops <= 3:
+            if self.main_menu_link.is_visible():
+                self.click(self.main_menu_link)
+            try:
+                if self.main_menu__header.is_visible():
+                    text = self.main_menu__header.text_content()
+                else:
+                    text = None
+            except Exception as e:
+                logging.warning(f"Could not read header text: {e}")
+                text = None
+
+            if text and self.main_menu_string in text:
+                break
+            else:
+                logging.warning("Main Menu click failed, retrying after 0.2 seconds")
+                # The timeout is in place here to allow the page ample time to load if it has not already been loaded
+                self.page.wait_for_timeout(200)
+
+            loops += 1
 
     def click_log_out_link(self) -> None:
         """Click the Base Page 'Log-out' link."""
@@ -101,7 +122,7 @@ class BasePage:
 
     def main_menu_header_is_displayed(self) -> None:
         """Asserts that the Main Menu header is displayed."""
-        expect(self.main_menu__header).to_contain_text("Main Menu")
+        expect(self.main_menu__header).to_contain_text(self.main_menu_string)
 
     def bowel_cancer_screening_page_title_contains_text(self, text: str) -> None:
         """Asserts that the page title contains the specified text.

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -57,6 +57,8 @@ class BasePage:
     def click_main_menu_link(self) -> None:
         """Click the Base Page 'Main Menu' link if it is visible."""
         loops = 0
+        text = None
+
         while loops <= 3:
             if self.main_menu_link.is_visible():
                 self.click(self.main_menu_link)
@@ -70,13 +72,17 @@ class BasePage:
                 text = None
 
             if text and self.main_menu_string in text:
-                break
+                return  # Success
             else:
                 logging.warning("Main Menu click failed, retrying after 0.2 seconds")
                 # The timeout is in place here to allow the page ample time to load if it has not already been loaded
                 self.page.wait_for_timeout(200)
 
             loops += 1
+        # All attempts failed
+        raise RuntimeError(
+            f"Failed to navigate to Main Menu after {loops} attempts. Last page title was: '{text or 'unknown'}'"
+        )
 
     def click_log_out_link(self) -> None:
         """Click the Base Page 'Log-out' link."""


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Improving the reliability of the main menu click method

## Context

<!-- Why is this change required? What problem does it solve? -->
Some tests would fail as the main menu link was clicked before the page fully loaded. This changes makes it so that once the main menu link is clicked it checks it has been redirected to the correct page.
If it has not then it waits 0.2 seconds and tries again.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
