### PR TITLE
BCSS-20562 - BCSS - Playwright - Review pytest markers

### DIFF
--- a/tests/test_call_and_recall_page.py
+++ b/tests/test_call_and_recall_page.py
@@ -60,6 +60,7 @@ def test_call_and_recall_page_navigation(page: Page) -> None:
     BasePage(page).main_menu_header_is_displayed()
 
 
+@pytest.mark.smoke
 def test_view_an_invitation_plan(page: Page, general_properties: dict) -> None:
     """
     Confirms that an invitation plan can be viewed via a screening centre from the planning ad monitoring page

--- a/tests/test_gfobt_test_kits_page.py
+++ b/tests/test_gfobt_test_kits_page.py
@@ -59,6 +59,7 @@ def test_gfobt_test_kit_page_navigation(page: Page) -> None:
     BasePage(page).main_menu_header_is_displayed()
 
 
+@pytest.mark.smoke
 def test_create_a_qc_kit(page: Page) -> None:
     """
     Confirms that a qc test kit can be created and that each of the dropdowns has an option set available for selection

--- a/tests/test_organisations_page.py
+++ b/tests/test_organisations_page.py
@@ -62,6 +62,7 @@ def test_organisations_page_navigation(page: Page) -> None:
     BasePage(page).bowel_cancer_screening_page_title_contains_text("Main Menu")
 
 
+@pytest.mark.smoke
 def test_view_an_organisations_system_parameters(
     page: Page, general_properties: dict
 ) -> None:

--- a/tests/test_reports_page.py
+++ b/tests/test_reports_page.py
@@ -19,6 +19,7 @@ def before_each(page: Page):
     BasePage(page).go_to_reports_page()
 
 
+@pytest.mark.smoke
 def test_reports_page_navigation(page: Page) -> None:
     """
     Confirms all menu items are displayed on the reports page, and that the relevant pages
@@ -65,6 +66,7 @@ def test_reports_page_navigation(page: Page) -> None:
     BasePage(page).bowel_cancer_screening_page_title_contains_text("Main Menu")
 
 
+@pytest.mark.smoke
 # Failsafe Reports
 def test_failsafe_reports_date_report_last_requested(page: Page) -> None:
     """
@@ -101,6 +103,7 @@ def test_failsafe_reports_date_report_last_requested(page: Page) -> None:
     )
 
 
+@pytest.mark.smoke
 def test_failsafe_reports_screening_subjects_with_inactive_open_episode(
     page: Page,
 ) -> None:
@@ -134,6 +137,7 @@ def test_failsafe_reports_screening_subjects_with_inactive_open_episode(
     )
 
 
+@pytest.mark.smoke
 def test_failsafe_reports_subjects_ceased_due_to_date_of_birth_changes(
     page: Page,
 ) -> None:
@@ -174,6 +178,7 @@ def test_failsafe_reports_subjects_ceased_due_to_date_of_birth_changes(
     )
 
 
+@pytest.mark.smoke
 def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundaries(
     page: Page, general_properties: dict
 ) -> None:
@@ -229,6 +234,7 @@ def test_failsafe_reports_allocate_sc_for_patient_movements_within_hub_boundarie
     )
 
 
+@pytest.mark.smoke
 def test_failsafe_reports_allocate_sc_for_patient_movements_into_your_hub(
     page: Page,
 ) -> None:
@@ -268,6 +274,7 @@ def test_failsafe_reports_allocate_sc_for_patient_movements_into_your_hub(
     )
 
 
+@pytest.mark.smoke
 def test_failsafe_reports_identify_and_link_new_gp(page: Page) -> None:
     """
     Confirms 'identify_and_link_new_gp' page loads,
@@ -315,6 +322,7 @@ def test_failsafe_reports_identify_and_link_new_gp(page: Page) -> None:
     )
 
 
+@pytest.mark.smoke
 # Operational Reports
 
 
@@ -363,6 +371,7 @@ def test_operational_reports_appointment_attendance_not_updated(
     BasePage(page).bowel_cancer_screening_page_title_contains_text("Appointment Detail")
 
 
+@pytest.mark.smoke
 def test_operational_reports_fobt_kits_logged_but_not_read(page: Page) -> None:
     """
     Confirms 'fobt_kits_logged_but_not_read' page loads,
@@ -393,6 +402,7 @@ def test_operational_reports_fobt_kits_logged_but_not_read(page: Page) -> None:
     ).to_contain_text(f"Report generated on {report_timestamp}.")
 
 
+@pytest.mark.smoke
 def test_operational_reports_demographic_update_inconsistent_with_manual_update(
     page: Page,
 ) -> None:
@@ -413,6 +423,7 @@ def test_operational_reports_demographic_update_inconsistent_with_manual_update(
     )
 
 
+@pytest.mark.smoke
 def test_operational_reports_screening_practitioner_6_weeks_availability_not_set_up(
     page: Page, general_properties: dict
 ) -> None:
@@ -462,6 +473,7 @@ def test_operational_reports_screening_practitioner_6_weeks_availability_not_set
     ).to_contain_text(report_timestamp)
 
 
+@pytest.mark.smoke
 def test_operational_reports_screening_practitioner_appointments(
     page: Page, general_properties: dict
 ) -> None:

--- a/tests/test_screening_subject_search_page.py
+++ b/tests/test_screening_subject_search_page.py
@@ -55,6 +55,7 @@ def test_search_screening_subject_by_nhs_number(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_surname(
     page: Page, general_properties: dict
 ) -> None:
@@ -72,6 +73,7 @@ def test_search_screening_subject_by_surname(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_forename(
     page: Page, general_properties: dict
 ) -> None:
@@ -89,6 +91,7 @@ def test_search_screening_subject_by_forename(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -> None:
     """
     Confirms a screening subject can be searched for, using their date of birth by doing the following:
@@ -104,6 +107,7 @@ def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_postcode(page: Page) -> None:
     """
     Confirms a screening subject can be searched for, using their postcode by doing the following:
@@ -119,6 +123,7 @@ def test_search_screening_subject_by_postcode(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_episode_closed_date(
     page: Page, general_properties: dict
 ) -> None:
@@ -142,6 +147,7 @@ def test_search_screening_subject_by_episode_closed_date(
     )
 
 
+@pytest.mark.smoke
 def test_search_criteria_clear_filters_button(
     page: Page, general_properties: dict
 ) -> None:
@@ -153,6 +159,7 @@ def test_search_criteria_clear_filters_button(
     check_clear_filters_button_works(page, general_properties["nhs_number"])
 
 
+@pytest.mark.smoke
 # Tests searching via the "Screening Status" drop down list
 def test_search_screening_subject_by_status_call(page: Page) -> None:
     """
@@ -169,6 +176,7 @@ def test_search_screening_subject_by_status_call(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_inactive(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -184,6 +192,7 @@ def test_search_screening_subject_by_status_inactive(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_opt_in(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -199,6 +208,7 @@ def test_search_screening_subject_by_status_opt_in(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_recall(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -214,6 +224,7 @@ def test_search_screening_subject_by_status_recall(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_self_referral(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -231,6 +242,7 @@ def test_search_screening_subject_by_status_self_referral(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_surveillance(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -248,6 +260,7 @@ def test_search_screening_subject_by_status_surveillance(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_seeking_further_data(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -265,6 +278,7 @@ def test_search_screening_subject_by_status_seeking_further_data(page: Page) -> 
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_ceased(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -280,6 +294,7 @@ def test_search_screening_subject_by_status_ceased(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_bowel_scope(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -297,6 +312,7 @@ def test_search_screening_subject_by_status_bowel_scope(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_lynch_surveillance(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -314,6 +330,7 @@ def test_search_screening_subject_by_status_lynch_surveillance(page: Page) -> No
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_lynch_self_referral(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -331,6 +348,7 @@ def test_search_screening_subject_by_status_lynch_self_referral(page: Page) -> N
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
+@pytest.mark.smoke
 # search_subject_by_latest_event_status
 def test_search_screening_subject_by_latest_episode_status_open_paused(
     page: Page,
@@ -351,6 +369,7 @@ def test_search_screening_subject_by_latest_episode_status_open_paused(
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_latest_episode_status_closed(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -368,6 +387,7 @@ def test_search_screening_subject_by_latest_episode_status_closed(page: Page) ->
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_latest_episode_status_no_episode(
     page: Page,
 ) -> None:
@@ -387,6 +407,7 @@ def test_search_screening_subject_by_latest_episode_status_no_episode(
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 # Tests searching via the "Search Area" drop down list
 def test_search_screening_subject_by_home_hub(page: Page) -> None:
     """
@@ -407,6 +428,7 @@ def test_search_screening_subject_by_home_hub(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_gp_practice(
     page: Page, general_properties: dict
 ) -> None:
@@ -434,6 +456,7 @@ def test_search_screening_subject_by_gp_practice(
     )
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (ccg) by doing the following:
@@ -457,6 +480,7 @@ def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.smoke
 def test_search_screening_subject_by_screening_centre(
     page: Page, general_properties: dict
 ) -> None:
@@ -480,6 +504,8 @@ def test_search_screening_subject_by_screening_centre(
     ).verify_subject_search_results_title_subject_search_results()
 
 
+@pytest.mark.vpn_required
+@pytest.mark.smoke
 def test_search_screening_subject_by_whole_database(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (whole database) by doing the following:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
This '@pytest.mark.smoke' is added for all functions in 'tests_' files under 'tests' folder as these are critical functions which will be considered during the Smoke Test run of Compartments (1 to 6).
This '@pytest.mark.vpn_required' is added only for functions which uses Database.

<!-- Describe your changes in detail. -->
## Context
Just it is a code review for pytest markers & No code change is implemeted.

<!-- Why is this change required? What problem does it solve? -->
## Type of changes
This line of syntax is added as it is required in order to identify & invoke all the critical functionalities when we are doing Smoke Test run of Compartments (1 to 6).

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [X] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [X] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

## Sensitive Information Declaration
To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [X] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
