### PR TITLE
Feature/bcss 20549–remove redundant page title verification methods from poms

### DIFF
--- a/pages/bowel_scope/bowel_scope_appointments_page.py
+++ b/pages/bowel_scope/bowel_scope_appointments_page.py
@@ -8,11 +8,10 @@ class BowelScopeAppointmentsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Bowel Scope Appointments - page locators
-        self.page_title = self.page.locator("#ntshPageTitle")
+        # Bowel Scope Appointments - page locators, methods
 
     def verify_page_title(self) -> None:
         """Verifies the page title of the Bowel Scope Appointments page"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Appointment Calendar"
         )

--- a/pages/bowel_scope/bowel_scope_appointments_page.py
+++ b/pages/bowel_scope/bowel_scope_appointments_page.py
@@ -13,4 +13,6 @@ class BowelScopeAppointmentsPage(BasePage):
 
     def verify_page_title(self) -> None:
         """Verifies the page title of the Bowel Scope Appointments page"""
-        expect(self.page_title).to_contain_text("Appointment Calendar")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Appointment Calendar"
+        )

--- a/pages/call_and_recall/age_extension_rollout_plans_page.py
+++ b/pages/call_and_recall/age_extension_rollout_plans_page.py
@@ -8,11 +8,10 @@ class AgeExtensionRolloutPlansPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Age Extension Rollout Plans - page locators
-        self.age_extension_rollout_plans_title = self.page.locator("#page-title")
+        # Age Extension Rollout Plans - page locators, methods
 
     def verify_age_extension_rollout_plans_title(self) -> None:
         """Verifies the page title of the Age Extension Rollout Plans page"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Age Extension Rollout Plans"
         )

--- a/pages/call_and_recall/age_extension_rollout_plans_page.py
+++ b/pages/call_and_recall/age_extension_rollout_plans_page.py
@@ -13,6 +13,6 @@ class AgeExtensionRolloutPlansPage(BasePage):
 
     def verify_age_extension_rollout_plans_title(self) -> None:
         """Verifies the page title of the Age Extension Rollout Plans page"""
-        expect(self.age_extension_rollout_plans_title).to_contain_text(
-            "Age Extension Rollout Plans"
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Age Extension Rollout Plans"    
         )

--- a/pages/call_and_recall/age_extension_rollout_plans_page.py
+++ b/pages/call_and_recall/age_extension_rollout_plans_page.py
@@ -14,5 +14,5 @@ class AgeExtensionRolloutPlansPage(BasePage):
     def verify_age_extension_rollout_plans_title(self) -> None:
         """Verifies the page title of the Age Extension Rollout Plans page"""
         BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Age Extension Rollout Plans"    
+            "Age Extension Rollout Plans"
         )

--- a/pages/call_and_recall/create_a_plan_page.py
+++ b/pages/call_and_recall/create_a_plan_page.py
@@ -23,7 +23,6 @@ class CreateAPlanPage(BasePage):
         self.save_note_button = self.page.locator("#saveNote").get_by_role(
             "button", name="Save"
         )
-        self.create_a_plan_title = self.page.locator("#page-title")
 
     def click_set_all_button(self) -> None:
         """Clicks the Set all button to set all values"""
@@ -59,6 +58,4 @@ class CreateAPlanPage(BasePage):
 
     def verify_create_a_plan_title(self) -> None:
         """Verifies the Create a Plan page title"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "View a plan"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("View a plan")

--- a/pages/call_and_recall/create_a_plan_page.py
+++ b/pages/call_and_recall/create_a_plan_page.py
@@ -59,4 +59,6 @@ class CreateAPlanPage(BasePage):
 
     def verify_create_a_plan_title(self) -> None:
         """Verifies the Create a Plan page title"""
-        expect(self.create_a_plan_title).to_contain_text("View a plan")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "View a plan"
+        )

--- a/pages/call_and_recall/generate_invitations_page.py
+++ b/pages/call_and_recall/generate_invitations_page.py
@@ -18,7 +18,6 @@ class GenerateInvitationsPage(BasePage):
         self.refresh_button = self.page.get_by_role("button", name="Refresh")
         self.planned_invitations_total = self.page.locator("#col8_total")
         self.self_referrals_total = self.page.locator("#col9_total")
-        self.generate_invitations_title = self.page.locator("#ntshPageTitle")
 
     def click_generate_invitations_button(self) -> None:
         """This function is used to click the Generate Invitations button."""
@@ -30,13 +29,11 @@ class GenerateInvitationsPage(BasePage):
 
     def verify_generate_invitations_title(self) -> None:
         """This function is used to verify the Generate Invitations page title."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Generate Invitations"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Generate Invitations")
 
     def verify_invitation_generation_progress_title(self) -> None:
         """This function is used to verify the Invitation Generation Progress page title."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Invitation Generation Progress"
         )
 

--- a/pages/call_and_recall/generate_invitations_page.py
+++ b/pages/call_and_recall/generate_invitations_page.py
@@ -30,11 +30,13 @@ class GenerateInvitationsPage(BasePage):
 
     def verify_generate_invitations_title(self) -> None:
         """This function is used to verify the Generate Invitations page title."""
-        expect(self.generate_invitations_title).to_contain_text("Generate Invitations")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Generate Invitations"
+        )
 
     def verify_invitation_generation_progress_title(self) -> None:
         """This function is used to verify the Invitation Generation Progress page title."""
-        expect(self.generate_invitations_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Invitation Generation Progress"
         )
 

--- a/pages/call_and_recall/invitations_monitoring_page.py
+++ b/pages/call_and_recall/invitations_monitoring_page.py
@@ -8,12 +8,11 @@ class InvitationsMonitoringPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        self.invitations_monitoring_title = self.page.locator("#page-title")
 
     def go_to_invitation_plan_page(self, sc_id) -> None:
         self.click(self.page.get_by_role("link", name=sc_id))
 
     def verify_invitations_monitoring_title(self) -> None:
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Invitations Monitoring - Screening Centre"
         )

--- a/pages/call_and_recall/invitations_monitoring_page.py
+++ b/pages/call_and_recall/invitations_monitoring_page.py
@@ -14,6 +14,6 @@ class InvitationsMonitoringPage(BasePage):
         self.click(self.page.get_by_role("link", name=sc_id))
 
     def verify_invitations_monitoring_title(self) -> None:
-        expect(self.invitations_monitoring_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Invitations Monitoring - Screening Centre"
         )

--- a/pages/call_and_recall/non_invitations_days_page.py
+++ b/pages/call_and_recall/non_invitations_days_page.py
@@ -8,11 +8,8 @@ class NonInvitationDaysPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Non Invitation Days - page locators
-        self.non_invitations_days_title = self.page.locator("#ntshPageTitle")
+        # Non Invitation Days - page locators, methods
 
     def verify_non_invitation_days_tile(self) -> None:
         """Verifies the page title of the Non Invitation Days page"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Non-Invitation Days"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Non-Invitation Days")

--- a/pages/call_and_recall/non_invitations_days_page.py
+++ b/pages/call_and_recall/non_invitations_days_page.py
@@ -13,4 +13,6 @@ class NonInvitationDaysPage(BasePage):
 
     def verify_non_invitation_days_tile(self) -> None:
         """Verifies the page title of the Non Invitation Days page"""
-        expect(self.non_invitations_days_title).to_contain_text("Non-Invitation Days")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Non-Invitation Days"
+        )

--- a/pages/communication_production/batch_list_page.py
+++ b/pages/communication_production/batch_list_page.py
@@ -35,7 +35,7 @@ class BatchListPage(BasePage):
 
     def verify_batch_list_page_title(self, text) -> None:
         """Verify the Batch List page title is displayed as expected"""
-        expect(self.batch_list_page_title).to_contain_text(text)
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(text)
 
     def verify_table_data(self, value) -> None:
         """Verify the table data is displayed as expected"""

--- a/pages/communication_production/batch_list_page.py
+++ b/pages/communication_production/batch_list_page.py
@@ -23,7 +23,6 @@ class BatchListPage(BasePage):
         self.batch_successfully_archived_msg = self.page.locator(
             'text="Batch Successfully Archived and Printed"'
         )
-        self.batch_list_page_title = self.page.locator("#page-title")
         self.deadline_calendar_picker = self.page.locator("i")
         self.deadline_date_filter = self.page.get_by_role("cell", name="").get_by_role(
             "textbox"
@@ -35,7 +34,7 @@ class BatchListPage(BasePage):
 
     def verify_batch_list_page_title(self, text) -> None:
         """Verify the Batch List page title is displayed as expected"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(text)
+        self.bowel_cancer_screening_page_title_contains_text(text)
 
     def verify_table_data(self, value) -> None:
         """Verify the table data is displayed as expected"""

--- a/pages/communication_production/electronic_communications_management_page.py
+++ b/pages/communication_production/electronic_communications_management_page.py
@@ -15,6 +15,6 @@ class ElectronicCommunicationManagementPage(BasePage):
 
     def verify_electronic_communication_management_title(self) -> None:
         """Verify the Electronic Communication Management page title is displayed as expected"""
-        expect(self.electronic_communication_management_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Electronic Communication Management"
         )

--- a/pages/communication_production/electronic_communications_management_page.py
+++ b/pages/communication_production/electronic_communications_management_page.py
@@ -8,13 +8,10 @@ class ElectronicCommunicationManagementPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Electronic Communication Management - page locators
-        self.electronic_communication_management_title = self.page.locator(
-            "#page-title"
-        )
+        # Electronic Communication Management - page locators, methods
 
     def verify_electronic_communication_management_title(self) -> None:
         """Verify the Electronic Communication Management page title is displayed as expected"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Electronic Communication Management"
         )

--- a/pages/communication_production/letter_library_index_page.py
+++ b/pages/communication_production/letter_library_index_page.py
@@ -8,11 +8,8 @@ class LetterLibraryIndexPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Letter Library Index - page locators
-        self.letter_library_index_title = self.page.locator("#ntshPageTitle")
+        # Letter Library Index - page locators, methods
 
     def verify_letter_library_index_title(self) -> None:
         """Verify the Letter Library Index page title is displayed as expected"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Letter Library Index"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Letter Library Index")

--- a/pages/communication_production/letter_library_index_page.py
+++ b/pages/communication_production/letter_library_index_page.py
@@ -13,4 +13,6 @@ class LetterLibraryIndexPage(BasePage):
 
     def verify_letter_library_index_title(self) -> None:
         """Verify the Letter Library Index page title is displayed as expected"""
-        expect(self.letter_library_index_title).to_contain_text("Letter Library Index")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Letter Library Index"
+        )

--- a/pages/communication_production/letter_signatory_page.py
+++ b/pages/communication_production/letter_signatory_page.py
@@ -13,4 +13,6 @@ class LetterSignatoryPage(BasePage):
 
     def verify_letter_signatory_title(self) -> None:
         """Verify the Letter Signatory page title is displayed as expected"""
-        expect(self.letter_signatory_title).to_contain_text("Letter Signatory")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Letter Signatory"
+        )

--- a/pages/communication_production/letter_signatory_page.py
+++ b/pages/communication_production/letter_signatory_page.py
@@ -8,11 +8,10 @@ class LetterSignatoryPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Letter Signatory - page locators
-        self.letter_signatory_title = self.page.locator("#ntshPageTitle")
+        # Letter Signatory - page locators, methods
 
     def verify_letter_signatory_title(self) -> None:
         """Verify the Letter Signatory page title is displayed as expected"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Letter Signatory"
         )

--- a/pages/contacts_list/edit_my_contact_details_page.py
+++ b/pages/contacts_list/edit_my_contact_details_page.py
@@ -8,11 +8,8 @@ class EditMyContactDetailsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Edit My Contact Details - page locators
-        self.edit_my_contact_details_title = self.page.locator("#ntshPageTitle")
+        # Edit My Contact Details - page locators, methods
 
     def verify_edit_my_contact_details_title(self) -> None:
         """Verify the Edit My Contact Details page title is displayed correctly"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Edit My Contact Details"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Edit My Contact Details")

--- a/pages/contacts_list/edit_my_contact_details_page.py
+++ b/pages/contacts_list/edit_my_contact_details_page.py
@@ -13,6 +13,6 @@ class EditMyContactDetailsPage(BasePage):
 
     def verify_edit_my_contact_details_title(self) -> None:
         """Verify the Edit My Contact Details page title is displayed correctly"""
-        expect(self.edit_my_contact_details_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Edit My Contact Details"
         )

--- a/pages/contacts_list/maintain_contacts_page.py
+++ b/pages/contacts_list/maintain_contacts_page.py
@@ -8,11 +8,8 @@ class MaintainContactsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Maintain Contacts - page locators
-        self.maintain_contacts_title = self.page.locator("#ntshPageTitle")
+        # Maintain Contacts - page locators, methods
 
     def verify_maintain_contacts_title(self) -> None:
         """Verify the Maintain Contacts page title is displayed correctly"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Maintain Contacts"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Maintain Contacts")

--- a/pages/contacts_list/maintain_contacts_page.py
+++ b/pages/contacts_list/maintain_contacts_page.py
@@ -13,4 +13,6 @@ class MaintainContactsPage(BasePage):
 
     def verify_maintain_contacts_title(self) -> None:
         """Verify the Maintain Contacts page title is displayed correctly"""
-        expect(self.maintain_contacts_title).to_contain_text("Maintain Contacts")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Maintain Contacts"
+        )

--- a/pages/contacts_list/my_preference_settings_page.py
+++ b/pages/contacts_list/my_preference_settings_page.py
@@ -13,6 +13,6 @@ class MyPreferenceSettingsPage(BasePage):
 
     def verify_my_preference_settings_title(self) -> None:
         """Verify the My Preference Settings page title is displayed correctly"""
-        expect(self.my_preference_settings_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "My Preference Settings"
         )

--- a/pages/contacts_list/my_preference_settings_page.py
+++ b/pages/contacts_list/my_preference_settings_page.py
@@ -8,11 +8,10 @@ class MyPreferenceSettingsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # My Preference Settings - page locators
-        self.my_preference_settings_title = self.page.locator("#ntshPageTitle")
+        # My Preference Settings - page locators, methods
 
     def verify_my_preference_settings_title(self) -> None:
         """Verify the My Preference Settings page title is displayed correctly"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "My Preference Settings"
         )

--- a/pages/contacts_list/view_contacts_page.py
+++ b/pages/contacts_list/view_contacts_page.py
@@ -13,4 +13,6 @@ class ViewContactsPage(BasePage):
 
     def verify_view_contacts_title(self) -> None:
         """Verify the View Contacts page title is displayed correctly"""
-        expect(self.view_contacts_title).to_contain_text("View Contacts")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "View Contacts"
+        )

--- a/pages/contacts_list/view_contacts_page.py
+++ b/pages/contacts_list/view_contacts_page.py
@@ -8,11 +8,10 @@ class ViewContactsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # View Contacts - page locators
-        self.view_contacts_title = self.page.locator("#ntshPageTitle")
+        # View Contacts - page locators, methods
 
     def verify_view_contacts_title(self) -> None:
         """Verify the View Contacts page title is displayed correctly"""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "View Contacts"
         )

--- a/pages/download/batch_download_request_and_retrieval_page.py
+++ b/pages/download/batch_download_request_and_retrieval_page.py
@@ -22,6 +22,6 @@ class BatchDownloadRequestAndRetrievalPage(BasePage):
 
     def verify_batch_download_request_and_retrieval_title(self) -> None:
         """Verifies that the Batch Download Request and Retrieval page title is displayed correctly."""
-        expect(self.batch_download_request_and_retrieval_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Batch Download Request and Retrieval"
         )

--- a/pages/download/batch_download_request_and_retrieval_page.py
+++ b/pages/download/batch_download_request_and_retrieval_page.py
@@ -9,9 +9,6 @@ class BatchDownloadRequestAndRetrievalPage(BasePage):
         super().__init__(page)
         self.page = page
         # Batch Download Request And Retrieval - page locators
-        self.batch_download_request_and_retrieval_title = self.page.locator(
-            "#ntshPageTitle"
-        )
         self.page_form = self.page.locator('form[name="frm"]')
 
     def expect_form_to_have_warning(self) -> None:
@@ -22,6 +19,6 @@ class BatchDownloadRequestAndRetrievalPage(BasePage):
 
     def verify_batch_download_request_and_retrieval_title(self) -> None:
         """Verifies that the Batch Download Request and Retrieval page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Batch Download Request and Retrieval"
         )

--- a/pages/download/individual_download_request_and_retrieval_page.py
+++ b/pages/download/individual_download_request_and_retrieval_page.py
@@ -16,7 +16,7 @@ class IndividualDownloadRequestAndRetrievalPage(BasePage):
 
     def verify_individual_download_request_and_retrieval_title(self) -> None:
         """Verifies that the Individual Download Request and Retrieval page title is displayed correctly."""
-        expect(self.individual_download_request_and_retrieval_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Individual Download Request and Retrieval"
         )
 

--- a/pages/download/individual_download_request_and_retrieval_page.py
+++ b/pages/download/individual_download_request_and_retrieval_page.py
@@ -9,14 +9,11 @@ class IndividualDownloadRequestAndRetrievalPage(BasePage):
         super().__init__(page)
         self.page = page
         # Individual Download Request And Retrieval - page locators
-        self.individual_download_request_and_retrieval_title = self.page.locator(
-            "#ntshPageTitle"
-        )
         self.page_form = self.page.locator('form[name="frm"]')
 
     def verify_individual_download_request_and_retrieval_title(self) -> None:
         """Verifies that the Individual Download Request and Retrieval page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Individual Download Request and Retrieval"
         )
 

--- a/pages/download/list_of_individual_downloads_page.py
+++ b/pages/download/list_of_individual_downloads_page.py
@@ -8,11 +8,10 @@ class ListOfIndividualDownloadsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # List Of Individual Downloads - page locators
-        self.list_of_individual_downloads_title = self.page.locator("#ntshPageTitle")
+        # List Of Individual Downloads - page locators, methods
 
     def verify_list_of_individual_downloads_title(self) -> None:
         """Verifies that the List of Individual Downloads page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "List of Individual Downloads"
         )

--- a/pages/download/list_of_individual_downloads_page.py
+++ b/pages/download/list_of_individual_downloads_page.py
@@ -13,6 +13,6 @@ class ListOfIndividualDownloadsPage(BasePage):
 
     def verify_list_of_individual_downloads_title(self) -> None:
         """Verifies that the List of Individual Downloads page title is displayed correctly."""
-        expect(self.list_of_individual_downloads_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "List of Individual Downloads"
         )

--- a/pages/fit_test_kits/fit_test_kits_page.py
+++ b/pages/fit_test_kits/fit_test_kits_page.py
@@ -44,7 +44,9 @@ class FITTestKitsPage(BasePage):
 
     def verify_fit_test_kits_title(self) -> None:
         """Verifies that the FIT Test Kits page title is displayed correctly."""
-        expect(self.fit_test_kits_title).to_contain_text("FIT Test Kits")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "FIT Test Kits"
+        )
 
     def go_to_fit_rollout_summary_page(self) -> None:
         """Navigates to the FIT Rollout Summary page."""

--- a/pages/fit_test_kits/fit_test_kits_page.py
+++ b/pages/fit_test_kits/fit_test_kits_page.py
@@ -36,17 +36,13 @@ class FITTestKitsPage(BasePage):
             "link", name="Maintain Analysers"
         )
         self.fit_device_id = self.page.get_by_role("textbox", name="FIT Device ID")
-        self.fit_test_kits_title = self.page.locator("#ntshPageTitle")
-
         self.sc_fit_configuration_page_screening_centre_dropdown = page.locator(
             "#screeningCentres"
         )
 
     def verify_fit_test_kits_title(self) -> None:
         """Verifies that the FIT Test Kits page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "FIT Test Kits"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("FIT Test Kits")
 
     def go_to_fit_rollout_summary_page(self) -> None:
         """Navigates to the FIT Rollout Summary page."""

--- a/pages/fit_test_kits/kit_result_audit_page.py
+++ b/pages/fit_test_kits/kit_result_audit_page.py
@@ -8,11 +8,10 @@ class KitResultAuditPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Kit Result Audit - page locators
-        self.kit_result_audit_title = self.page.locator("#page-title")
+        # Kit Result Audit - page locators, methods
 
     def verify_kit_result_audit_title(self) -> None:
         """Verifies that the Kit Result Audit page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Kit Result Audit"
         )

--- a/pages/fit_test_kits/kit_result_audit_page.py
+++ b/pages/fit_test_kits/kit_result_audit_page.py
@@ -13,4 +13,6 @@ class KitResultAuditPage(BasePage):
 
     def verify_kit_result_audit_title(self) -> None:
         """Verifies that the Kit Result Audit page title is displayed correctly."""
-        expect(self.kit_result_audit_title).to_contain_text("Kit Result Audit")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Kit Result Audit"
+        )

--- a/pages/fit_test_kits/kit_service_management_page.py
+++ b/pages/fit_test_kits/kit_service_management_page.py
@@ -13,6 +13,6 @@ class KitServiceManagementPage(BasePage):
 
     def verify_kit_service_management_title(self) -> None:
         """Verifies that the Kit Service Management page title is displayed correctly."""
-        expect(self.kit_service_management_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Kit Service Management"
         )

--- a/pages/fit_test_kits/kit_service_management_page.py
+++ b/pages/fit_test_kits/kit_service_management_page.py
@@ -8,11 +8,8 @@ class KitServiceManagementPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # KIT Service Management - page locators
-        self.kit_service_management_title = self.page.locator("#page-title")
+        # KIT Service Management - page locators, methods
 
     def verify_kit_service_management_title(self) -> None:
         """Verifies that the Kit Service Management page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Kit Service Management"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Kit Service Management")

--- a/pages/fit_test_kits/log_devices_page.py
+++ b/pages/fit_test_kits/log_devices_page.py
@@ -33,7 +33,7 @@ class LogDevicesPage(BasePage):
 
     def verify_log_devices_title(self) -> None:
         """Verifies that the Log Devices page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Scan Device"
         )
 

--- a/pages/fit_test_kits/log_devices_page.py
+++ b/pages/fit_test_kits/log_devices_page.py
@@ -33,7 +33,9 @@ class LogDevicesPage(BasePage):
 
     def verify_log_devices_title(self) -> None:
         """Verifies that the Log Devices page title is displayed correctly."""
-        expect(self.log_devices_title).to_contain_text("Scan Device")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Scan Device"
+        )
 
     def fill_fit_device_id_field(self, value) -> None:
         """Fills the FIT Device ID field with the provided value and presses Enter."""

--- a/pages/fit_test_kits/maintain_analysers_page.py
+++ b/pages/fit_test_kits/maintain_analysers_page.py
@@ -8,11 +8,8 @@ class MaintainAnalysersPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Maintain Analysers - page locators
-        self.maintain_analysers_title = self.page.locator("#ntshPageTitle")
+        # Maintain Analysers - page locators, methods
 
     def verify_maintain_analysers_title(self) -> None:
         """Verify the Maintain Analysers page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Maintain Analysers"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Maintain Analysers")

--- a/pages/fit_test_kits/maintain_analysers_page.py
+++ b/pages/fit_test_kits/maintain_analysers_page.py
@@ -13,4 +13,6 @@ class MaintainAnalysersPage(BasePage):
 
     def verify_maintain_analysers_title(self) -> None:
         """Verify the Maintain Analysers page title is displayed correctly."""
-        expect(self.maintain_analysers_title).to_contain_text("Maintain Analysers")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Maintain Analysers"
+        )

--- a/pages/fit_test_kits/manage_qc_products_page.py
+++ b/pages/fit_test_kits/manage_qc_products_page.py
@@ -8,11 +8,10 @@ class ManageQCProductsPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Manage QC Products - page locators
-        self.manage_qc_products_title = self.page.locator("#page-title")
+        # Manage QC Products - page locators, methods
 
     def verify_manage_qc_products_title(self) -> None:
         """Verify the Manage QC Products page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "FIT QC Products"
         )

--- a/pages/fit_test_kits/manage_qc_products_page.py
+++ b/pages/fit_test_kits/manage_qc_products_page.py
@@ -13,4 +13,6 @@ class ManageQCProductsPage(BasePage):
 
     def verify_manage_qc_products_title(self) -> None:
         """Verify the Manage QC Products page title is displayed correctly."""
-        expect(self.manage_qc_products_title).to_contain_text("FIT QC Products")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "FIT QC Products"
+        )

--- a/pages/fit_test_kits/screening_incidents_list_page.py
+++ b/pages/fit_test_kits/screening_incidents_list_page.py
@@ -8,11 +8,10 @@ class ScreeningIncidentsListPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Screening Incidents List - page locators
-        self.screening_incidents_list_title = self.page.locator("#page-title")
+        # Screening Incidents List - page locators, methods
 
     def verify_screening_incidents_list_title(self) -> None:
         """Verify the Screening Incidents List page title is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Screening Incidents List"
         )

--- a/pages/fit_test_kits/screening_incidents_list_page.py
+++ b/pages/fit_test_kits/screening_incidents_list_page.py
@@ -13,6 +13,6 @@ class ScreeningIncidentsListPage(BasePage):
 
     def verify_screening_incidents_list_title(self) -> None:
         """Verify the Screening Incidents List page title is displayed correctly."""
-        expect(self.screening_incidents_list_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Screening Incidents List"
         )

--- a/pages/gfobt_test_kits/gfobt_create_qc_kit_page.py
+++ b/pages/gfobt_test_kits/gfobt_create_qc_kit_page.py
@@ -23,7 +23,9 @@ class CreateQCKitPage(BasePage):
 
     def verify_create_qc_kit_title(self) -> None:
         """Verify the Create QC Kit page title contains text "Create QC Kit"."""
-        expect(self.create_qc_kit_title).to_contain_text("Create QC Kit")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Create QC Kit"
+        )
 
     def go_to_reading1dropdown(self, option: str) -> None:
         """Selects a given option from the reading 1 dropdown."""

--- a/pages/gfobt_test_kits/gfobt_create_qc_kit_page.py
+++ b/pages/gfobt_test_kits/gfobt_create_qc_kit_page.py
@@ -23,7 +23,7 @@ class CreateQCKitPage(BasePage):
 
     def verify_create_qc_kit_title(self) -> None:
         """Verify the Create QC Kit page title contains text "Create QC Kit"."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Create QC Kit"
         )
 

--- a/pages/gfobt_test_kits/gfobt_test_kit_logging_page.py
+++ b/pages/gfobt_test_kits/gfobt_test_kit_logging_page.py
@@ -8,10 +8,7 @@ class GFOBTTestKitLoggingPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        self.test_kit_logging_title = self.page.locator("#ntshPageTitle")
 
     def verify_test_kit_logging_title(self) -> None:
         """Verify the title of the GFOBT Test Kit Logging page."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "Test Kit Logging"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("Test Kit Logging")

--- a/pages/gfobt_test_kits/gfobt_test_kit_logging_page.py
+++ b/pages/gfobt_test_kits/gfobt_test_kit_logging_page.py
@@ -12,4 +12,6 @@ class GFOBTTestKitLoggingPage(BasePage):
 
     def verify_test_kit_logging_title(self) -> None:
         """Verify the title of the GFOBT Test Kit Logging page."""
-        expect(self.test_kit_logging_title).to_contain_text("Test Kit Logging")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "Test Kit Logging"
+        )

--- a/pages/gfobt_test_kits/gfobt_test_kit_quality_control_reading_page.py
+++ b/pages/gfobt_test_kits/gfobt_test_kit_quality_control_reading_page.py
@@ -8,12 +8,9 @@ class GFOBTTestKitQualityControlReadingPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        self.test_kit_quality_control_reading_title = self.page.locator(
-            "#ntshPageTitle"
-        )
 
     def verify_test_kit_logging_tile(self) -> None:
         """Verify the title of the GFOBT Test Kit Quality Control Reading page."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Test Kit Quality Control Reading"
         )

--- a/pages/gfobt_test_kits/gfobt_test_kit_quality_control_reading_page.py
+++ b/pages/gfobt_test_kits/gfobt_test_kit_quality_control_reading_page.py
@@ -14,6 +14,6 @@ class GFOBTTestKitQualityControlReadingPage(BasePage):
 
     def verify_test_kit_logging_tile(self) -> None:
         """Verify the title of the GFOBT Test Kit Quality Control Reading page."""
-        expect(self.test_kit_quality_control_reading_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Test Kit Quality Control Reading"
         )

--- a/pages/gfobt_test_kits/gfobt_view_test_kit_result_page.py
+++ b/pages/gfobt_test_kits/gfobt_view_test_kit_result_page.py
@@ -8,10 +8,7 @@ class ViewTestKitResultPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        self.view_test_kit_result_title = self.page.locator("#ntshPageTitle")
 
     def verify_view_test_kit_result_title(self) -> None:
         """Verify the title of the View Test Kit Result page."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
-            "View Test Kit Result"
-        )
+        self.bowel_cancer_screening_page_title_contains_text("View Test Kit Result")

--- a/pages/gfobt_test_kits/gfobt_view_test_kit_result_page.py
+++ b/pages/gfobt_test_kits/gfobt_view_test_kit_result_page.py
@@ -12,4 +12,6 @@ class ViewTestKitResultPage(BasePage):
 
     def verify_view_test_kit_result_title(self) -> None:
         """Verify the title of the View Test Kit Result page."""
-        expect(self.view_test_kit_result_title).to_contain_text("View Test Kit Result")
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+            "View Test Kit Result"
+        )

--- a/pages/lynch_surveillance/set_lynch_invitation_rates_page.py
+++ b/pages/lynch_surveillance/set_lynch_invitation_rates_page.py
@@ -13,6 +13,6 @@ class SetLynchInvitationRatesPage(BasePage):
 
     def verify_set_lynch_invitation_rates_title(self) -> None:
         """Verifies that the Set Lynch Invitation Rates title is displayed."""
-        expect(self.set_lynch_invitation_rates_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Set Lynch Surveillance Invitation Rates"
         )

--- a/pages/lynch_surveillance/set_lynch_invitation_rates_page.py
+++ b/pages/lynch_surveillance/set_lynch_invitation_rates_page.py
@@ -8,11 +8,10 @@ class SetLynchInvitationRatesPage(BasePage):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        # Lynch Invitation Page - Links
-        self.set_lynch_invitation_rates_title = self.page.locator("#page-title")
+        # Lynch Invitation Page - Links, methods
 
     def verify_set_lynch_invitation_rates_title(self) -> None:
         """Verifies that the Set Lynch Invitation Rates title is displayed."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Set Lynch Surveillance Invitation Rates"
         )

--- a/pages/screening_practitioner_appointments/colonoscopy_assessment_appointments_page.py
+++ b/pages/screening_practitioner_appointments/colonoscopy_assessment_appointments_page.py
@@ -18,7 +18,7 @@ class ColonoscopyAssessmentAppointmentsPage(BasePage):
 
     def verify_page_header(self) -> None:
         """Verifies the Colonoscopy Assessment Appointments page header is displayed correctly."""
-        expect(self.page_header).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Patients that Require Colonoscopy Assessment Appointments"
         )
 

--- a/pages/screening_practitioner_appointments/colonoscopy_assessment_appointments_page.py
+++ b/pages/screening_practitioner_appointments/colonoscopy_assessment_appointments_page.py
@@ -9,7 +9,6 @@ class ColonoscopyAssessmentAppointmentsPage(BasePage):
         super().__init__(page)
         self.page = page
         # Colonoscopy Assessment Appointments - page locators
-        self.page_header = self.page.locator("#page-title")
         self.page_header_with_title = self.page.locator(
             "#page-title",
             has_text="Patients that Require Colonoscopy Assessment Appointments",
@@ -18,7 +17,7 @@ class ColonoscopyAssessmentAppointmentsPage(BasePage):
 
     def verify_page_header(self) -> None:
         """Verifies the Colonoscopy Assessment Appointments page header is displayed correctly."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Patients that Require Colonoscopy Assessment Appointments"
         )
 

--- a/pages/screening_subject_search/subject_screening_summary_page.py
+++ b/pages/screening_subject_search/subject_screening_summary_page.py
@@ -66,13 +66,13 @@ class SubjectScreeningSummaryPage(BasePage):
 
     def verify_subject_search_results_title_subject_screening_summary(self) -> None:
         """Verify that the subject search results title contains 'Subject Screening Summary'."""
-        expect(self.subject_search_results_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Subject Screening Summary"
         )
 
     def verify_subject_search_results_title_subject_search_results(self) -> None:
         """Verify that the subject search results title contains 'Subject Search Results'."""
-        expect(self.subject_search_results_title).to_contain_text(
+        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
             "Subject Search Results"
         )
 

--- a/pages/screening_subject_search/subject_screening_summary_page.py
+++ b/pages/screening_subject_search/subject_screening_summary_page.py
@@ -46,7 +46,6 @@ class SubjectScreeningSummaryPage(BasePage):
         self.a_page_to_close_the_episode = self.page.get_by_text(
             "go to a page to Close the"
         )
-        self.subject_search_results_title = self.page.locator("#ntshPageTitle")
         self.display_rs = self.page.locator("#displayRS")
         self.first_fobt_episode_link = page.get_by_role(
             "link", name="FOBT Screening"
@@ -66,13 +65,13 @@ class SubjectScreeningSummaryPage(BasePage):
 
     def verify_subject_search_results_title_subject_screening_summary(self) -> None:
         """Verify that the subject search results title contains 'Subject Screening Summary'."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Subject Screening Summary"
         )
 
     def verify_subject_search_results_title_subject_search_results(self) -> None:
         """Verify that the subject search results title contains 'Subject Search Results'."""
-        BasePage(self.page).bowel_cancer_screening_page_title_contains_text(
+        self.bowel_cancer_screening_page_title_contains_text(
             "Subject Search Results"
         )
 

--- a/tests/test_fit_test_kits_page.py
+++ b/tests/test_fit_test_kits_page.py
@@ -30,7 +30,7 @@ def before_each(page: Page):
     BasePage(page).go_to_fit_test_kits_page()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_fit_test_kits_page_navigation(page: Page, general_properties: dict) -> None:
     """
     Confirms all menu items are displayed on the fit test kits page, and that the relevant pages

--- a/tests/test_fit_test_kits_page.py
+++ b/tests/test_fit_test_kits_page.py
@@ -30,7 +30,7 @@ def before_each(page: Page):
     BasePage(page).go_to_fit_test_kits_page()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_fit_test_kits_page_navigation(page: Page, general_properties: dict) -> None:
     """
     Confirms all menu items are displayed on the fit test kits page, and that the relevant pages

--- a/tests/test_screening_subject_search_page.py
+++ b/tests/test_screening_subject_search_page.py
@@ -37,7 +37,7 @@ def before_each(page: Page):
     BasePage(page).go_to_screening_subject_search_page()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_nhs_number(
     page: Page, general_properties: dict
 ) -> None:
@@ -55,7 +55,7 @@ def test_search_screening_subject_by_nhs_number(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_surname(
     page: Page, general_properties: dict
 ) -> None:
@@ -73,7 +73,7 @@ def test_search_screening_subject_by_surname(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_forename(
     page: Page, general_properties: dict
 ) -> None:
@@ -91,7 +91,7 @@ def test_search_screening_subject_by_forename(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -> None:
     """
     Confirms a screening subject can be searched for, using their date of birth by doing the following:
@@ -107,7 +107,7 @@ def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_postcode(page: Page) -> None:
     """
     Confirms a screening subject can be searched for, using their postcode by doing the following:
@@ -123,7 +123,7 @@ def test_search_screening_subject_by_postcode(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_episode_closed_date(
     page: Page, general_properties: dict
 ) -> None:
@@ -159,7 +159,7 @@ def test_search_criteria_clear_filters_button(
     check_clear_filters_button_works(page, general_properties["nhs_number"])
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 # Tests searching via the "Screening Status" drop down list
 def test_search_screening_subject_by_status_call(page: Page) -> None:
     """
@@ -176,7 +176,7 @@ def test_search_screening_subject_by_status_call(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_inactive(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -192,7 +192,7 @@ def test_search_screening_subject_by_status_inactive(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_opt_in(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -208,7 +208,7 @@ def test_search_screening_subject_by_status_opt_in(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_recall(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -224,7 +224,7 @@ def test_search_screening_subject_by_status_recall(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_self_referral(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -242,7 +242,7 @@ def test_search_screening_subject_by_status_self_referral(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_surveillance(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -260,7 +260,7 @@ def test_search_screening_subject_by_status_surveillance(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_seeking_further_data(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -278,7 +278,7 @@ def test_search_screening_subject_by_status_seeking_further_data(page: Page) -> 
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_ceased(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -294,7 +294,7 @@ def test_search_screening_subject_by_status_ceased(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_lynch_surveillance(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -312,7 +312,7 @@ def test_search_screening_subject_by_status_lynch_surveillance(page: Page) -> No
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_status_lynch_self_referral(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -330,7 +330,7 @@ def test_search_screening_subject_by_status_lynch_self_referral(page: Page) -> N
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 # search_subject_by_latest_event_status
 def test_search_screening_subject_by_latest_episode_status_open_paused(
     page: Page,
@@ -351,7 +351,7 @@ def test_search_screening_subject_by_latest_episode_status_open_paused(
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_latest_episode_status_closed(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -369,7 +369,7 @@ def test_search_screening_subject_by_latest_episode_status_closed(page: Page) ->
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_latest_episode_status_no_episode(
     page: Page,
 ) -> None:
@@ -389,7 +389,7 @@ def test_search_screening_subject_by_latest_episode_status_no_episode(
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 # Tests searching via the "Search Area" drop down list
 def test_search_screening_subject_by_home_hub(page: Page) -> None:
     """
@@ -410,7 +410,7 @@ def test_search_screening_subject_by_home_hub(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_gp_practice(
     page: Page, general_properties: dict
 ) -> None:
@@ -438,7 +438,7 @@ def test_search_screening_subject_by_gp_practice(
     )
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (ccg) by doing the following:
@@ -462,7 +462,7 @@ def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_screening_centre(
     page: Page, general_properties: dict
 ) -> None:
@@ -487,7 +487,7 @@ def test_search_screening_subject_by_screening_centre(
 
 
 @pytest.mark.vpn_required
-@pytest.mark.smoked
+@pytest.mark.smoke
 def test_search_screening_subject_by_whole_database(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (whole database) by doing the following:

--- a/tests/test_screening_subject_search_page.py
+++ b/tests/test_screening_subject_search_page.py
@@ -37,7 +37,7 @@ def before_each(page: Page):
     BasePage(page).go_to_screening_subject_search_page()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_nhs_number(
     page: Page, general_properties: dict
 ) -> None:
@@ -55,7 +55,7 @@ def test_search_screening_subject_by_nhs_number(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_surname(
     page: Page, general_properties: dict
 ) -> None:
@@ -73,7 +73,7 @@ def test_search_screening_subject_by_surname(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_forename(
     page: Page, general_properties: dict
 ) -> None:
@@ -91,7 +91,7 @@ def test_search_screening_subject_by_forename(
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -> None:
     """
     Confirms a screening subject can be searched for, using their date of birth by doing the following:
@@ -107,7 +107,7 @@ def test_search_screening_subject_by_dob(page: Page, general_properties: dict) -
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_postcode(page: Page) -> None:
     """
     Confirms a screening subject can be searched for, using their postcode by doing the following:
@@ -123,7 +123,7 @@ def test_search_screening_subject_by_postcode(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_episode_closed_date(
     page: Page, general_properties: dict
 ) -> None:
@@ -159,7 +159,7 @@ def test_search_criteria_clear_filters_button(
     check_clear_filters_button_works(page, general_properties["nhs_number"])
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 # Tests searching via the "Screening Status" drop down list
 def test_search_screening_subject_by_status_call(page: Page) -> None:
     """
@@ -176,7 +176,7 @@ def test_search_screening_subject_by_status_call(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_inactive(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -192,7 +192,7 @@ def test_search_screening_subject_by_status_inactive(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_opt_in(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -208,7 +208,7 @@ def test_search_screening_subject_by_status_opt_in(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_recall(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -224,7 +224,7 @@ def test_search_screening_subject_by_status_recall(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_self_referral(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -242,7 +242,7 @@ def test_search_screening_subject_by_status_self_referral(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_surveillance(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -260,7 +260,7 @@ def test_search_screening_subject_by_status_surveillance(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_seeking_further_data(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -278,7 +278,7 @@ def test_search_screening_subject_by_status_seeking_further_data(page: Page) -> 
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_ceased(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -294,25 +294,7 @@ def test_search_screening_subject_by_status_ceased(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
-def test_search_screening_subject_by_status_bowel_scope(page: Page) -> None:
-    """
-    Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
-    - Clear filters
-    - Select status from dropdown
-    - Pressing Tab is required after text input, to make the search button become active.
-    - Click search button
-    - Verify the subject search results page is displayed
-    """
-    search_subject_by_status(
-        page, ScreeningStatusSearchOptions.BOWEL_SCOPE_STATUS.value
-    )
-    SubjectScreeningSummaryPage(
-        page
-    ).verify_subject_search_results_title_subject_search_results()
-
-
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_lynch_surveillance(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -330,7 +312,7 @@ def test_search_screening_subject_by_status_lynch_surveillance(page: Page) -> No
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_status_lynch_self_referral(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -348,7 +330,7 @@ def test_search_screening_subject_by_status_lynch_self_referral(page: Page) -> N
     ).verify_subject_search_results_title_subject_screening_summary()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 # search_subject_by_latest_event_status
 def test_search_screening_subject_by_latest_episode_status_open_paused(
     page: Page,
@@ -369,7 +351,7 @@ def test_search_screening_subject_by_latest_episode_status_open_paused(
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_latest_episode_status_closed(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the screening status (call) by doing the following:
@@ -387,7 +369,7 @@ def test_search_screening_subject_by_latest_episode_status_closed(page: Page) ->
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_latest_episode_status_no_episode(
     page: Page,
 ) -> None:
@@ -407,7 +389,7 @@ def test_search_screening_subject_by_latest_episode_status_no_episode(
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 # Tests searching via the "Search Area" drop down list
 def test_search_screening_subject_by_home_hub(page: Page) -> None:
     """
@@ -428,7 +410,7 @@ def test_search_screening_subject_by_home_hub(page: Page) -> None:
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_gp_practice(
     page: Page, general_properties: dict
 ) -> None:
@@ -456,7 +438,7 @@ def test_search_screening_subject_by_gp_practice(
     )
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (ccg) by doing the following:
@@ -480,7 +462,7 @@ def test_search_screening_subject_by_ccg(page: Page, general_properties: dict) -
     ).verify_subject_search_results_title_subject_search_results()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_screening_centre(
     page: Page, general_properties: dict
 ) -> None:
@@ -505,7 +487,7 @@ def test_search_screening_subject_by_screening_centre(
 
 
 @pytest.mark.vpn_required
-@pytest.mark.smoke
+@pytest.mark.smoked
 def test_search_screening_subject_by_whole_database(page: Page) -> None:
     """
     Confirms screening subjects can be searched for, using the search area (whole database) by doing the following:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Replaced in pom page title verification methods with the basepage method that does the same thing.

## Context

<!-- Why is this change required? What problem does it solve? -->
Removes repetition and improves code maintainability.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](https://github.com/nhs-england-tools/playwright-python-blueprint/blob/main/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes (where appropriate)
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
